### PR TITLE
Deploy to Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [Settings]
-  ID = "publicmapping"
+  ID = "districtbuilder"
 
 [build]
   base = "."

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,27 @@
+[Settings]
+  ID = "publicmapping"
+
+[build]
+  base = "."
+  publish = "_site/"
+  command = "jekyll build"
+
+[context.production.environment]
+  JEKYLL_ENV = "production"
+
+[context.deploy-preview.environment]
+  JEKYLL_ENV = "development"
+
+[context.branch-deploy.environment]
+  JEKYLL_ENV = "development"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = """
+      default-src 'self';
+      """
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "no-referrer"

--- a/netlify.toml
+++ b/netlify.toml
@@ -20,6 +20,7 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
+      script-src 'self' 'unsafe-inline';
       """
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,9 +12,6 @@
 [context.deploy-preview.environment]
   JEKYLL_ENV = "development"
 
-[context.branch-deploy.environment]
-  JEKYLL_ENV = "development"
-
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
## Overview

Establishes a `netlify.toml` config to deploy the `master`, `develop`, and PR branches to Netlify.

## Testing Instructions

- Confirm that the [Netlify deploy preview build](https://app.netlify.com/sites/districtbuilder/deploys/5ef36279926191000755929c) passes.
- Go to the [deploy preview](https://5ef36279926191000755929c--districtbuilder.netlify.app/) and confirm that a default Jenkins site loads with no content security policy errors in the console.

Resolves #3 