### PR TITLE
Add Google Analytics to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,7 +17,7 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
-      script-src 'self' 'unsafe-inline' https://www.googletagmanager.com use.typekit.net;
+      script-src 'self' 'unsafe-inline' https://www.googletagmanager.com use.typekit.net https://www.google-analytics.com;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net;
       img-src 'self' www.googletagmanager.com p.typekit.net;
       font-src 'self' data://* use.typekit.net;

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
       default-src 'self';
       script-src 'self' 'unsafe-inline' https://www.googletagmanager.com use.typekit.net https://www.google-analytics.com;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net;
-      img-src 'self' www.googletagmanager.com p.typekit.net;
+      img-src 'self' www.googletagmanager.com p.typekit.net https://www.google-analytics.com;
       font-src 'self' data://* use.typekit.net;
       """
     X-Frame-Options = "DENY"

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,7 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
+      connect-src 'self' https://www.google-analytics.com;
       script-src 'self' 'unsafe-inline' https://www.googletagmanager.com use.typekit.net https://www.google-analytics.com;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net;
       img-src 'self' www.googletagmanager.com p.typekit.net https://www.google-analytics.com;

--- a/netlify.toml
+++ b/netlify.toml
@@ -20,7 +20,7 @@
       connect-src 'self' https://www.google-analytics.com;
       script-src 'self' 'unsafe-inline' https://www.googletagmanager.com use.typekit.net https://www.google-analytics.com;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net;
-      img-src 'self' www.googletagmanager.com p.typekit.net https://www.google-analytics.com;
+      img-src 'self' https://www.googletagmanager.com p.typekit.net https://www.google-analytics.com;
       font-src 'self' data://* use.typekit.net;
       """
     X-Frame-Options = "DENY"


### PR DESCRIPTION
I noticed Google Analytics was getting blocked by our CSP for our current splash page website:
![image](https://user-images.githubusercontent.com/14098314/93235121-22ff8380-f74b-11ea-883f-a8c90f361e08.png)

I think we just need to whitelist GA in our `script-src` so I'm attempting to do that.