### PR TITLE
Add Hubspot to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,7 +20,7 @@
       connect-src 'self' https://www.google-analytics.com;
       script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://tagmanager.google.com use.typekit.net https://www.google-analytics.com https://kit.fontawesome.com https://js.hs-scripts.com https://js.hs-scripts.net https://js.hs-banner.com https://js.hs-analytics.net;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net https://kit-pro.fontawesome.com https://tagmanager.google.com https://fonts.googleapis.com;
-      img-src 'self' https://www.googletagmanager.com p.typekit.net https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com;
+      img-src 'self' https://www.googletagmanager.com p.typekit.net https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com https://track.hubspot.com;
       font-src 'self' data: use.typekit.net https://kit-pro.fontawesome.com https://fonts.gstatic.com;
       """
     X-Frame-Options = "DENY"


### PR DESCRIPTION
Adds `https://track.hubspot.com/` to `img-src` in our CSP to prevent it from being blocked, per Alex's request:

>site has some errors and issues in the console re: CSP stuff (picture in thread). Most notably for HubSpot
![image](https://user-images.githubusercontent.com/14098314/94064669-05b85e00-fdb8-11ea-81ef-68490e335c5b.png)
